### PR TITLE
Update omniauth-oauth2 version constraints

### DIFF
--- a/omniauth-zoom.gemspec
+++ b/omniauth-zoom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '> 2.0'
 
-  gem.add_dependency 'omniauth-oauth2'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.8.0'
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency "rspec", "> 3"


### PR DESCRIPTION
Updates omniauth-oauth2 constraints to make the gem compatible with omniauth 2